### PR TITLE
Update to "identifier" format

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -208,8 +208,8 @@
   "isAbout": [
     {
       "identifier": {
-        "identifier": "10090",
-        "identifierSource":"https://www.ncbi.nlm.nih.gov/taxonomy/10090"
+        "identifier": "https://www.ncbi.nlm.nih.gov/taxonomy/10090",
+		"identifierSource": "NCBI Taxonomy Database"
       },
       "name":"Mus musculus"
     }


### PR DESCRIPTION
This PR corrects the usage of `identifier` and `identifierSource` in the taxonomic data under the `isAbout` entry in `DATS.json` in keeping with https://github.com/CONP-PCNO/conp-dataset/issues/712.